### PR TITLE
[TECHNICAL-SUPPORT] LPS-59060

### DIFF
--- a/modules/portal/portal-ldap/src/com/liferay/portal/ldap/ContactConverterKeys.java
+++ b/modules/portal/portal-ldap/src/com/liferay/portal/ldap/ContactConverterKeys.java
@@ -25,13 +25,13 @@ public interface ContactConverterKeys {
 
 	public static final String FACEBOOK_SN = "facebookSn";
 
-	public static final String GENDER = "gender";
-
 	public static final String ICQ_SN = "icqSn";
 
 	public static final String JABBER_SN = "jabberSn";
 
 	public static final String JOB_TITLE = "jobTitle";
+
+	public static final String MALE = "male";
 
 	public static final String MSN_SN = "msnSn";
 

--- a/modules/portal/portal-ldap/src/com/liferay/portal/ldap/exportimport/DefaultLDAPToPortalConverter.java
+++ b/modules/portal/portal-ldap/src/com/liferay/portal/ldap/exportimport/DefaultLDAPToPortalConverter.java
@@ -167,12 +167,12 @@ public class DefaultLDAPToPortalConverter implements LDAPToPortalConverter {
 
 		contact.setSuffixId(suffixId);
 
-		String gender = LDAPUtil.getAttributeString(
-			attributes, contactMappings, ContactConverterKeys.GENDER);
+		String male = LDAPUtil.getAttributeString(
+			attributes, contactMappings, ContactConverterKeys.MALE);
 
-		gender = StringUtil.toLowerCase(gender);
+		male = StringUtil.toLowerCase(male);
 
-		if (GetterUtil.getBoolean(gender) || gender.equals("female")) {
+		if (GetterUtil.getBoolean(male) || male.equals("female")) {
 			contact.setMale(false);
 		}
 		else {

--- a/modules/portal/portal-ldap/src/com/liferay/portal/ldap/exportimport/DefaultLDAPToPortalConverter.java
+++ b/modules/portal/portal-ldap/src/com/liferay/portal/ldap/exportimport/DefaultLDAPToPortalConverter.java
@@ -172,7 +172,7 @@ public class DefaultLDAPToPortalConverter implements LDAPToPortalConverter {
 
 		male = StringUtil.toLowerCase(male);
 
-		if (GetterUtil.getBoolean(male) || male.equals("female")) {
+		if (!GetterUtil.getBoolean(male) || male.equals("female")) {
 			contact.setMale(false);
 		}
 		else {


### PR DESCRIPTION
Hey Minhchau,

This is a bug fix to allow the user's gender to be exporter properly via vLDAP. I am unsure if there was a reason for using 'gender' instead of 'male' to begin with, but with the logic found in https://github.com/liferay/liferay-portal/blob/master/modules/portal/portal-ldap/src/com/liferay/portal/ldap/exportimport/LDAPUserImporterImpl.java#L1286, if the attribute is not found in the contact mapping property, it won't be imported. In order to get 'gender' to map correctly to 'male' the mapping looks like 'gender=male', but since the user importer is looking for a key of 'male', the attribute isn't imported.

Let me know if you have any questions or concerns though.

Related to https://github.com/holatuwol/liferay-plugins-ee/pull/32