### PR TITLE
LPS-82603 2

### DIFF
--- a/modules/apps/portal-scheduler/portal-scheduler-multiple/src/main/java/com/liferay/portal/scheduler/multiple/internal/ClusterSchedulerEngine.java
+++ b/modules/apps/portal-scheduler/portal-scheduler-multiple/src/main/java/com/liferay/portal/scheduler/multiple/internal/ClusterSchedulerEngine.java
@@ -50,9 +50,11 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
@@ -599,6 +601,18 @@ public class ClusterSchedulerEngine
 				return;
 			}
 			catch (Exception e) {
+				if (!(e instanceof TimeoutException)) {
+					CompletableFuture completableFuture =
+						new CompletableFuture();
+
+					try {
+						completableFuture.get(
+							_callMasterTimeout, TimeUnit.SECONDS);
+					}
+					catch (Exception e2) {
+					}
+				}
+
 				StringBundler sb = new StringBundler(5);
 
 				sb.append(

--- a/modules/apps/portal/portal-cluster-multiple/src/main/java/com/liferay/portal/cluster/multiple/internal/ClusterMasterExecutorImpl.java
+++ b/modules/apps/portal/portal-cluster-multiple/src/main/java/com/liferay/portal/cluster/multiple/internal/ClusterMasterExecutorImpl.java
@@ -37,6 +37,8 @@ import com.liferay.portal.kernel.util.Validator;
 
 import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
@@ -186,11 +188,27 @@ public class ClusterMasterExecutorImpl implements ClusterMasterExecutor {
 				masterClusterNodeId = _localClusterNodeId;
 			}
 			else {
-				ClusterNode clusterNode = _clusterExecutorImpl.getClusterNode(
-					coordinatorAddress);
+				CompletableFuture<ClusterNode> completableFuture =
+					new CompletableFuture<>();
 
-				if (clusterNode != null) {
+				CompletableFuture.runAsync(
+					() -> {
+						ClusterNode clusterNode =
+							_clusterExecutorImpl.getClusterNode(
+								coordinatorAddress);
+
+						if (clusterNode != null) {
+							completableFuture.complete(clusterNode);
+						}
+					});
+
+				try {
+					ClusterNode clusterNode = completableFuture.get(
+						_GET_CLUSTER_NODE_TIMEOUT, TimeUnit.SECONDS);
+
 					masterClusterNodeId = clusterNode.getClusterNodeId();
+				}
+				catch (Exception e) {
 				}
 			}
 
@@ -250,6 +268,8 @@ public class ClusterMasterExecutorImpl implements ClusterMasterExecutor {
 		_clusterMasterTokenTransitionListeners.addAll(
 			clusterMasterTokenTransitionListeners);
 	}
+
+	private static final long _GET_CLUSTER_NODE_TIMEOUT = 1;
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		ClusterMasterExecutorImpl.class);


### PR DESCRIPTION
**Ticket:** https://issues.liferay.com/browse/LPS-82603 
**previous pr:** https://github.com/tinatian/liferay-portal/pull/939

Hi @holatuwol,

This pr is for the **race condition clustering issue** you worked on, where **log messages** were being **spammed** within a **while loop** and the **proposed fix** is to add a **1 second delay**.

Per our discussion with Tina, we were advised to avoid using **Thread.sleep** and to instead use **Future.get()**.

## Brief Summary

The **first commit** is pretty straight-forward.
The **second commit** tries to address a concern you mentioned on the previous pr.

Can you verify if the **second commit** addresses your concerns?

**Edit:**
~**CI Test Results:** https://github.com/ericyanLr/liferay-portal/pull/75#issuecomment-409053766~

Just make a modification to the Second Commit. I noticed that the exception can also throw **CancellationException**, not just **ExecutionException**. The revised logic would introduce a timeout, as long as the Exception was not caused by a TimeoutException.

Re-running ci:test:relevant.
**CI Test Results:** https://github.com/ericyanLr/liferay-portal/pull/75#issuecomment-409305297

Please let me know if you have any questions.
Thanks!

----
## Additional Details

### First Commit: https://github.com/holatuwol/liferay-portal/commit/0d89e4a07e6f66df757a0a5d9763a8f2a2ca4ee1

This commit is pretty straight-forward; the change introduces a **future** that only completes when a non-null **ClusterNode** is returned. 

This ensures that the timeout is acknowledged within the loop.

### Second Commit: https://github.com/holatuwol/liferay-portal/commit/67cc52edf7aaff0c5abe714c741188fd148d70ae

For this commit, our main concern is: 
`List<SchedulerResponse> schedulerResponses = future.get(_callMasterTimeout, TimeUnit.SECONDS);`

From your notes, you mentioned a concern:

> In ClusterSchedulerEngine, future.get(_callMasterTimeout, TimeUnit.SECONDS) will return null early (in our customer's case, it was returning instantly) and not block for the full _callmasterTimeout, resulting in an infinite no-delay loop.

But, looking at the code, it looks like if that future returns a null, it would soon hit a **return** statement and end the while loop.

Can you verify if that is really the case?

#### Changes
To account for other possible edge cases,  this commit modifies the **catch (Exception e)** clause to account for **ExecutionException**. 

future.get() throws: **InterruptedException**, **ExecutionException**, and **TimeoutException**

Looking at the original code, the **try block** handled an **InterruptedException** and a general **Exception**. 

The general **Exception** looks like it was made primarily for the **TimeoutException**. But, if an **ExecutionException** were to be thrown, the timeout would not be satisfied.

This changes make it so if an **ExecutionException** were to be thrown, we would make sure that the timeout would be satisfied.

- Note: This probably introduces a timeout that is longer than expected, since we won't be sure how much time the original future that threw this exception actually spent.