### PR TITLE
[TS] Prompt 2 - DM Folder Name: Remove escape text in Document and Media portlet

### DIFF
--- a/modules/apps/collaboration/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_entries.jsp
+++ b/modules/apps/collaboration/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_entries.jsp
@@ -503,7 +503,7 @@ if (portletTitleBasedNavigation && (folderId != DLFolderConstants.DEFAULT_PARENT
 									actionJspServletContext="<%= application %>"
 									resultRow="<%= row %>"
 									rowChecker="<%= entriesChecker %>"
-									text="<%= HtmlUtil.escape(curFolder.getName()) %>"
+									text="<%= curFolder.getName() %>"
 									url="<%= rowURL.toString() %>"
 								>
 									<liferay-frontend:horizontal-card-col>

--- a/modules/apps/collaboration/document-library/document-library-web/src/main/resources/META-INF/resources/image_gallery_display/view_images.jsp
+++ b/modules/apps/collaboration/document-library/document-library-web/src/main/resources/META-INF/resources/image_gallery_display/view_images.jsp
@@ -93,7 +93,7 @@ DLPortletInstanceSettingsHelper dlPortletInstanceSettingsHelper = new DLPortletI
 				%>
 
 				<liferay-ui:search-container-column-text>
-					<div class="image-link preview" <%= (hasAudio || hasVideo) ? "data-options=\"height=" + playerHeight + "&thumbnailURL=" + HtmlUtil.escapeURL(DLUtil.getPreviewURL(fileEntry, fileVersion, themeDisplay, "&videoThumbnail=1")) + "&width=640" + dataOptions + "\"" : StringPool.BLANK %> href="<%= imageURL %>" thumbnailId="<%= thumbnailId %>" title="<%= HtmlUtil.escapeAttribute(title) %>">
+					<div class="image-link preview" <%= (hasAudio || hasVideo) ? "data-options=\"height=" + playerHeight + "&thumbnailURL=" + HtmlUtil.escapeURL(DLUtil.getPreviewURL(fileEntry, fileVersion, themeDisplay, "&videoThumbnail=1")) + "&width=640" + dataOptions + "\"" : StringPool.BLANK %> href="<%= imageURL %>" thumbnailId="<%= thumbnailId %>" title="<%= title %>">
 						<c:choose>
 							<c:when test="<%= Validator.isNull(imageURL) %>">
 								<liferay-frontend:icon-vertical-card
@@ -135,7 +135,7 @@ DLPortletInstanceSettingsHelper dlPortletInstanceSettingsHelper = new DLPortletI
 						actionJsp='<%= dlPortletInstanceSettingsHelper.isShowActions() ? "/document_library/folder_action.jsp" : StringPool.BLANK %>'
 						actionJspServletContext="<%= application %>"
 						resultRow="<%= row %>"
-						text="<%= HtmlUtil.escape(curFolder.getName()) %>"
+						text="<%= curFolder.getName() %>"
 						url="<%= viewFolderURL %>"
 					>
 						<liferay-frontend:horizontal-card-col>

--- a/modules/apps/collaboration/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/group_selector/page.jsp
+++ b/modules/apps/collaboration/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/group_selector/page.jsp
@@ -65,7 +65,7 @@ SearchContainer searchContainer = new GroupSearch(liferayPortletRequest, iterato
 			<liferay-ui:search-container-column-text colspan="<%= 3 %>">
 				<liferay-frontend:horizontal-card
 					resultRow="<%= row %>"
-					text="<%= HtmlUtil.escape(curGroup.getDescriptiveName(locale)) %>"
+					text="<%= curGroup.getDescriptiveName(locale) %>"
 					url="<%= viewGroupURL.toString() %>"
 				>
 					<liferay-frontend:horizontal-card-col>

--- a/modules/apps/collaboration/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/repository_entry_browser/page.jsp
+++ b/modules/apps/collaboration/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/repository_entry_browser/page.jsp
@@ -315,7 +315,7 @@ if (Validator.isNotNull(keywords)) {
 									<liferay-ui:search-container-column-text colspan="<%= 3 %>">
 										<liferay-frontend:horizontal-card
 											resultRow="<%= row %>"
-											text="<%= HtmlUtil.escape(folder.getName()) %>"
+											text="<%= folder.getName() %>"
 											url="<%= viewFolderURL.toString() %>"
 										>
 											<liferay-frontend:horizontal-card-col>

--- a/modules/apps/collaboration/wiki/wiki-web/src/main/resources/META-INF/resources/wiki/view.jsp
+++ b/modules/apps/collaboration/wiki/wiki-web/src/main/resources/META-INF/resources/wiki/view.jsp
@@ -378,7 +378,7 @@ if (portletTitleBasedNavigation) {
 
 												<div class="col-md-4">
 													<liferay-frontend:horizontal-card
-														text="<%= HtmlUtil.escape(fileEntry.getTitle()) %>"
+														text="<%= fileEntry.getTitle() %>"
 														url="<%= rowURL %>"
 													>
 														<liferay-frontend:horizontal-card-col>

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/article_attachments.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/article_attachments.jsp
@@ -41,7 +41,7 @@ if (kbArticle != null) {
 
 				<div class="col-md-4">
 					<liferay-frontend:horizontal-card
-						text="<%= HtmlUtil.escape(fileEntry.getTitle()) %>"
+						text="<%= fileEntry.getTitle() %>"
 						url="<%= rowURL %>"
 					>
 						<liferay-frontend:horizontal-card-col>

--- a/modules/apps/web-experience/journal/journal-web/src/main/resources/META-INF/resources/view_entries.jsp
+++ b/modules/apps/web-experience/journal/journal-web/src/main/resources/META-INF/resources/view_entries.jsp
@@ -298,7 +298,7 @@ String searchContainerId = ParamUtil.getString(request, "searchContainerId");
 								actionJspServletContext="<%= application %>"
 								resultRow="<%= row %>"
 								rowChecker="<%= articleSearchContainer.getRowChecker() %>"
-								text="<%= HtmlUtil.escape(curFolder.getName()) %>"
+								text="<%= curFolder.getName() %>"
 								url="<%= rowURL.toString() %>"
 							>
 								<liferay-frontend:horizontal-card-col>

--- a/modules/apps/web-experience/trash/trash-web/src/main/resources/META-INF/resources/view_content.jsp
+++ b/modules/apps/web-experience/trash/trash-web/src/main/resources/META-INF/resources/view_content.jsp
@@ -184,7 +184,7 @@ renderResponse.setTitle(trashRenderer.getTitle(locale));
 											actionJsp="/view_content_action.jsp"
 											actionJspServletContext="<%= application %>"
 											resultRow="<%= row %>"
-											text="<%= HtmlUtil.escape(curTrashRenderer.getTitle(locale)) %>"
+											text="<%= curTrashRenderer.getTitle(locale) %>"
 											url="<%= rowURL.toString() %>"
 										>
 										</liferay-frontend:horizontal-card>


### PR DESCRIPTION
@holatuwol Please help me review this PR.

When i make changes in foundation/frontend-taglib, I'm not sure I can cover where the tag is used and I can't test all about it.

So I changed in the Document and Media portlet, Media Gallery portlet. And I found an error: No result with the keyword "&" in Documents and Media portlet.

Test script.
-------------------------------------------------------------------------------------------
Precondition: 

- Add the "&" folder and the "&" image into Document and Media Portlet.

Steps to check:

**Document and Media.**

- Check with Info, Icon, Descriptive, and List view.
- Delete, undo and check.

**Recycle Bin.**
- Delete all, go to Recycle Bin, and check with Info, Icon, Descriptive, and List view.

**Media Gallery.**
- Check view.
- Check text when hover and preview.

**Add all the portlets in Collaboration, Content Management group. Focus on some portlets below:**
- Most Viewed Assets.
- Asset Publisher.
- Highest Rated Assets.
- Recent Download.

If i miss some things, please let me know.
Thank you.

