### PR TITLE
[TS] Prompt 2 - DM Pagination: Fix bug pagination in Document and Media portlet

### DIFF
--- a/modules/apps/collaboration/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_entries.jsp
+++ b/modules/apps/collaboration/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_entries.jsp
@@ -21,6 +21,7 @@ String navigation = ParamUtil.getString(request, "navigation", "home");
 
 String currentFolder = ParamUtil.getString(request, "curFolder");
 String deltaFolder = ParamUtil.getString(request, "deltaFolder");
+int entriesPerPage = dlPortletInstanceSettings.getEntriesPerPage();
 
 long folderId = GetterUtil.getLong((String)request.getAttribute("view.jsp-folderId"));
 
@@ -53,7 +54,7 @@ portletURL.setParameter("curFolder", currentFolder);
 portletURL.setParameter("deltaFolder", deltaFolder);
 portletURL.setParameter("folderId", String.valueOf(folderId));
 
-SearchContainer dlSearchContainer = new SearchContainer(liferayPortletRequest, null, null, "curEntry", SearchContainer.DEFAULT_DELTA, portletURL, null, null);
+SearchContainer dlSearchContainer = new SearchContainer(liferayPortletRequest, null, null, "curEntry", entriesPerPage, portletURL, null, null);
 
 EntriesChecker entriesChecker = new EntriesChecker(liferayPortletRequest, liferayPortletResponse);
 


### PR DESCRIPTION
@holatuwol Please help me review this PR.

Test script.
--------------------------------------------------------------
Steps to reproduce:
1. Add a Documents and Media portlet.
2. Add 7 folders in the DM porlet.
3. Click the configuration of DM.
4. Select 5 of "Maximum Entries to Display "
5. Click Save and refresh the page.

Result: The default results per page and number of folder displayed does not changed.

Checked on Knowledge Base, Message Board, Wiki, and Media Display portlet. They do not have this configuration.

Thank you.