### PR TITLE
[TS] Prompt 3 - Session Expired: Sync sessionState and timestamp

### DIFF
--- a/modules/apps/foundation/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/session.js
+++ b/modules/apps/foundation/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/session.js
@@ -340,6 +340,16 @@ AUI.add(
 									timeOffset = Math.floor((Date.now() - timestamp) / 1000) * 1000;
 
 									elapsed = timeOffset;
+
+									if (instance._initTimestamp != timestamp) {
+										instance._initTimestamp = timestamp;
+
+										var sessionState = instance.get('sessionState');
+
+										if (sessionState != 'active') {
+											instance.set('sessionState', 'active', SRC_EVENT_OBJ);
+										}
+									}
 								}
 								else {
 									timestamp = 'expired';
@@ -360,9 +370,7 @@ AUI.add(
 										hasExpired = true;
 									}
 
-									var sessionState = instance.get('sessionState');
-
-									if (hasExpired && sessionState != 'expired') {
+									if (hasExpired) {
 										if (extend) {
 											expirationMoment = false;
 											hasExpired = false;
@@ -377,7 +385,7 @@ AUI.add(
 											expirationMoment = true;
 										}
 									}
-									else if (hasWarned && !hasExpired && !extend && sessionState != 'warned') {
+									else if (!extend) {
 										instance.warn();
 
 										warningMoment = true;


### PR DESCRIPTION
@holatuwol Please help me review this PR for Session Expired Prompt 3

Test script
---------------------------------
1. Edit Liferay_home/tomcat/webapps/ROOT/WEB-INF/web.xml and change <session-timeout>30</session-timeout> to <session-timeout>2</session-timeout>
2. Start Liferay session and log in in tab 1.
3. Duplicate tab (tab 2)
4. Make sure you can see both tabs (or windows)
5. Wait for session-expiration-warning message to be displayed
6. Click to extend the session in tab 1.
7. Wait for session-expiration-warning message to be displayed.
8. Click to extend the session in tab 2.
9. Wait for session-expiration-warning message to be displayed.
10. Wait for session-expiration-danger message to be displayed.

Result:
- In step 5, session-expiration-warning message displays on both tabs.
- After step 6, warning message goes away on both pages.
- In step 7, session-expiration-warning message displays on both tabs.
- After step 8, warning message goes away on both pages.
- In step 9, session-expiration-warning message displays on both tabs.
- In step 8, session-expiration-danger message displays on both tabs.

Thanks so much.