### PR TITLE
LPS-114577: Add test

### DIFF
--- a/modules/apps/portal/portal-util-test/src/testIntegration/java/com/liferay/portal/util/test/PortalImplLayoutFriendlyURLTest.java
+++ b/modules/apps/portal/portal-util-test/src/testIntegration/java/com/liferay/portal/util/test/PortalImplLayoutFriendlyURLTest.java
@@ -88,6 +88,14 @@ public class PortalImplLayoutFriendlyURLTest {
 	}
 
 	@Test
+	public void testCompanyDefaultSiteVirtualHostWithoutLayoutSetVirtualHost()
+		throws Exception {
+
+		_testLayoutFriendlyURL(
+			_company.getVirtualHostname(), _layout.getFriendlyURL());
+	}
+
+	@Test
 	public void testLayoutSetVirtualHost() throws Exception {
 		_testLayoutFriendlyURL(
 			_setLayoutSetVirtualHost(), _layout.getFriendlyURL());


### PR DESCRIPTION
Hi Minh Chau,
I have updated my work to add integration tests.
I found that there was a test for the case that does not allow us to remove `/web/site-friendly-URL` when the site's virtual host is set: https://github.com/liferay/liferay-portal/blob/7.3.2-ga3/modules/apps/portal/portal-util-test/src/testIntegration/java/com/liferay/portal/util/test/PortalImplLayoutFriendlyURLTest.java#L78-L88

I added a function for the remaining case - the site's virtual host is not set.
Please help me to review and give me your feedback.
Thanks