### PR TITLE
[TS][Prompt-2]WCM-Content-Tags: Fix cannot add webcontent with same tags

### DIFF
--- a/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetTagLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetTagLocalServiceImpl.java
@@ -122,6 +122,8 @@ public class AssetTagLocalServiceImpl extends AssetTagLocalServiceBaseImpl {
 		List<AssetTag> tags = new ArrayList<>();
 
 		for (String name : names) {
+			name = StringUtil.toLowerCase(StringUtil.trim(name));
+
 			AssetTag tag = fetchTag(group.getGroupId(), name);
 
 			if (tag == null) {


### PR DESCRIPTION
Hi @holatuwol,
Because of all tags should be lowercase and trimmed before added to db, but the logic to compare the exist tags didn't do that, then the error happens.
Please help me to review it.
Thanks.