### PR TITLE
[TS][Prompt-3]Session extend popup didn't show properly on multiple tab

### DIFF
--- a/modules/apps/foundation/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/session.js
+++ b/modules/apps/foundation/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/session.js
@@ -505,7 +505,7 @@ AUI.add(
 						instance._intervalId = host.registerInterval(
 							function(elapsed, interval, hasWarned, hasExpired, warningMoment, expirationMoment) {
 								if (!hasWarned) {
-									instance._uiSetActivated();
+									host.extend();
 								}
 								else if (!hasExpired) {
 									if (warningMoment) {


### PR DESCRIPTION
Hi @holatuwol ,
I found that, when click on **extend** link from one browser the other **sessionState** didn't change to _active_. Therefore the condition check on line 308 is always failed then the warning popup cannot show up.
The line 508 will be call when the new cookie come in on the browser didn't click **extend** link. However the statement `instance._uiSetActivated();` just hide the banner and unRegister the interval.
To fix that bug, we will make the behavior of the second browser like the one clicked **extend** link by change to `host.extend()`. It'll set the new sessionState to _active_, and trigger the function to hide the banner.

Beside that, I also discover more on how session extend and expired on backend.

I ran the source format, but seem like it not affect the js file:

```
ant setup-sdk compile
cd portal-impl
ant format-source-current-branch -Dgit.working.branch.name=3c0c3a9498004721c85bf266ea43942285c6665b
```
By the way, could you tell me more about
`/gradlew npmRunFormat`
I ran it, but it not take all js file into account. How can we adjust that to make it verify the js file on module?   

Please help me to review it.
Thank you.