### PR TITLE
[TS] Prompt 3 set active session state

### DIFF
--- a/modules/apps/foundation/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/session.js
+++ b/modules/apps/foundation/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/session.js
@@ -505,7 +505,7 @@ AUI.add(
 						instance._intervalId = host.registerInterval(
 							function(elapsed, interval, hasWarned, hasExpired, warningMoment, expirationMoment) {
 								if (!hasWarned) {
-									instance._uiSetActivated();
+									host.set('sessionState', 'active', SRC_EVENT_OBJ);
 								}
 								else if (!hasExpired) {
 									if (warningMoment) {


### PR DESCRIPTION
Hi @holatuwol,

I have finish reproduced, investigated, debugged and fixed this Session state expire prompt.
During debug process, I found the root cause is session status of other tab/window is not be change when click Extend button on one tab.
I think the purpose of this prompt is learning about see how to use session, session cross tab/window/browser, debug javascript on browser and see the working follow of frontend code.

After fixed it, I run source format code by follow: 
```
ant setup-sdk compile
cd portal-impl
ant format-source-current-branch -D.git.working.branch.name=3c0c3a9498004721c85bf266ea43942285c6665b
```
And I see it show messsage: "This target does not format .es.js files."
So I run bellow command as the suggest after run above command: (and I don't see any error related to my changed)
```
cd modules/
../gradlew npmRunFormat
```

Please help me take a look.
Thank you