### PR TITLE
LPS-116291: Remove portlet resource param in redirect url

### DIFF
--- a/modules/apps/product-navigation/product-navigation-control-menu-web/src/main/resources/META-INF/resources/view_resources.jsp
+++ b/modules/apps/product-navigation/product-navigation-control-menu-web/src/main/resources/META-INF/resources/view_resources.jsp
@@ -102,8 +102,6 @@ if (Validator.isNotNull(keywords)) {
 
 	<%
 	String redirectURL = PortalUtil.getLayoutFullURL(layout, themeDisplay);
-
-	redirectURL = HttpUtil.addParameter(redirectURL, "portletResource", portletDisplay.getId());
 	%>
 
 	<liferay-asset:asset-add-button


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-116291

This problem occurs in all options in the "Add" pane.
I remove the portlet resource parameter in the redirect url. So after adding new content, it will be redirected to the original url.

Example: The new redirect url is 
http://localhost:8080/web/guest/wp
instead of 
http://localhost:8080/web/guest/wp?portletResource=com_liferay_product_navigation_control_menu_web_portlet_ProductNavigationControlMenuPortlet&_com_liferay_product_navigation_control_menu_web_portlet_ProductNavigationControlMenuPortlet_className=com.liferay.journal.model.JournalArticle&_com_liferay_product_navigation_control_menu_web_portlet_ProductNavigationControlMenuPortlet_classPK=38405

Please help me to review it. Thank you.