### PR TITLE
Get right groupdId and add hasViewPermission for workflow asset

### DIFF
--- a/modules/apps/forms-and-workflow/portal-workflow/portal-workflow-task-web/src/main/java/com/liferay/portal/workflow/task/web/permission/WorkflowTaskPermissionChecker.java
+++ b/modules/apps/forms-and-workflow/portal-workflow/portal-workflow-task-web/src/main/java/com/liferay/portal/workflow/task/web/permission/WorkflowTaskPermissionChecker.java
@@ -14,12 +14,22 @@
 
 package com.liferay.portal.workflow.task.web.permission;
 
+import com.liferay.asset.kernel.model.AssetRenderer;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Role;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.kernel.workflow.WorkflowHandler;
+import com.liferay.portal.kernel.workflow.WorkflowHandlerRegistryUtil;
 import com.liferay.portal.kernel.workflow.WorkflowTask;
 import com.liferay.portal.kernel.workflow.WorkflowTaskAssignee;
+
+import java.io.Serializable;
+
+import java.util.Map;
 
 /**
  * @author Adam Brandizzi
@@ -37,7 +47,8 @@ public class WorkflowTaskPermissionChecker {
 		}
 
 		if (!permissionChecker.isContentReviewer(
-				permissionChecker.getCompanyId(), groupId)) {
+				permissionChecker.getCompanyId(), groupId) &&
+			!hasAssetViewPermission(permissionChecker, workflowTask)) {
 
 			return false;
 		}
@@ -58,6 +69,32 @@ public class WorkflowTaskPermissionChecker {
 		}
 
 		return false;
+	}
+
+	protected boolean hasAssetViewPermission(
+		PermissionChecker permissionChecker, WorkflowTask workflowTask) {
+
+		Map<String, Serializable> workflowTaskOptionalAttributes =
+			workflowTask.getOptionalAttributes();
+
+		String entryClassName = GetterUtil.getString(
+			workflowTaskOptionalAttributes.get(
+				WorkflowConstants.CONTEXT_ENTRY_CLASS_NAME));
+
+		long entryClassPK = GetterUtil.getLong(
+			workflowTaskOptionalAttributes.get(
+				WorkflowConstants.CONTEXT_ENTRY_CLASS_PK));
+
+		try {
+			WorkflowHandler<?> workflowHandler =
+				WorkflowHandlerRegistryUtil.getWorkflowHandler(entryClassName);
+			AssetRenderer<?> assetRenderer = workflowHandler.getAssetRenderer(
+				entryClassPK);
+			return assetRenderer.hasViewPermission(permissionChecker);
+		}
+		catch (PortalException pe) {
+			return false;
+		}
 	}
 
 	protected boolean isWorkflowTaskAssignableToRoles(

--- a/modules/apps/forms-and-workflow/portal-workflow/portal-workflow-task-web/src/main/java/com/liferay/portal/workflow/task/web/portlet/MyWorkflowTaskPortlet.java
+++ b/modules/apps/forms-and-workflow/portal-workflow/portal-workflow-task-web/src/main/java/com/liferay/portal/workflow/task/web/portlet/MyWorkflowTaskPortlet.java
@@ -20,10 +20,12 @@ import com.liferay.portal.kernel.portlet.bridges.mvc.MVCPortlet;
 import com.liferay.portal.kernel.security.auth.PrincipalException;
 import com.liferay.portal.kernel.servlet.SessionErrors;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.PortletKeys;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.kernel.workflow.WorkflowException;
 import com.liferay.portal.kernel.workflow.WorkflowTask;
 import com.liferay.portal.kernel.workflow.WorkflowTaskManagerUtil;
@@ -123,9 +125,12 @@ public class MyWorkflowTaskPortlet extends MVCPortlet {
 			WorkflowTask workflowTask, ThemeDisplay themeDisplay)
 		throws PortalException {
 
+		long groupId =
+			GetterUtil.getLong(workflowTask.getOptionalAttributes().get(
+				WorkflowConstants.CONTEXT_GROUP_ID));
+
 		if (!_workflowTaskPermissionChecker.hasPermission(
-				themeDisplay.getScopeGroupId(), workflowTask,
-				themeDisplay.getPermissionChecker())) {
+				groupId, workflowTask, themeDisplay.getPermissionChecker())) {
 
 			throw new PrincipalException(
 				String.format(

--- a/modules/apps/forms-and-workflow/portal-workflow/portal-workflow-task-web/src/main/java/com/liferay/portal/workflow/task/web/portlet/action/AssignTaskMVCActionCommand.java
+++ b/modules/apps/forms-and-workflow/portal-workflow/portal-workflow-task-web/src/main/java/com/liferay/portal/workflow/task/web/portlet/action/AssignTaskMVCActionCommand.java
@@ -17,9 +17,11 @@ package com.liferay.portal.workflow.task.web.portlet.action;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCActionCommand;
 import com.liferay.portal.kernel.security.auth.PrincipalException;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.PortletKeys;
 import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.kernel.workflow.WorkflowTask;
 import com.liferay.portal.kernel.workflow.WorkflowTaskManagerUtil;
 import com.liferay.portal.workflow.task.web.permission.WorkflowTaskPermissionChecker;
@@ -50,9 +52,12 @@ public class AssignTaskMVCActionCommand
 		WorkflowTask workflowTask = WorkflowTaskManagerUtil.getWorkflowTask(
 			themeDisplay.getCompanyId(), workflowTaskId);
 
+		long groupId =
+			GetterUtil.getLong(workflowTask.getOptionalAttributes().get(
+				WorkflowConstants.CONTEXT_GROUP_ID));
+
 		if (!_workflowTaskPermissionChecker.hasPermission(
-				themeDisplay.getScopeGroupId(), workflowTask,
-				themeDisplay.getPermissionChecker())) {
+				groupId, workflowTask, themeDisplay.getPermissionChecker())) {
 
 			throw new PrincipalException(
 				String.format(


### PR DESCRIPTION
I ran the ant source-format-current-branch and got error: 
[java] Exception in thread "main" java.util.concurrent.ExecutionException: java.lang.NullPointerException
     [java] 	at java.util.concurrent.FutureTask.report(FutureTask.java:122)
     [java] 	at java.util.concurrent.FutureTask.get(FutureTask.java:192)
     [java] 	at com.liferay.source.formatter.SourceFormatter.format(SourceFormatter.java:195)
     [java] 	at com.liferay.source.formatter.SourceFormatter.main(SourceFormatter.java:136)
     [java] Caused by: java.lang.NullPointerException
     [java] 	at com.liferay.portal.kernel.io.unsync.UnsyncStringReader.<init>(UnsyncStringReader.java:34)
     [java] 	at com.liferay.source.formatter.BaseSourceProcessor.readXML(BaseSourceProcessor.java:2435)
     [java] 	at com.liferay.source.formatter.JSPSourceProcessor._populateTagJavaClasses(JSPSourceProcessor.java:1931)
     [java] 	at com.liferay.source.formatter.JSPSourceProcessor.preFormat(JSPSourceProcessor.java:1887)
     [java] 	at com.liferay.source.formatter.BaseSourceProcessor.format(BaseSourceProcessor.java:90)
     [java] 	at com.liferay.source.formatter.SourceFormatter._runSourceProcessor(SourceFormatter.java:249)
     [java] 	at com.liferay.source.formatter.SourceFormatter.access$000(SourceFormatter.java:40)
     [java] 	at com.liferay.source.formatter.SourceFormatter$1.call(SourceFormatter.java:181)
     [java] 	at com.liferay.source.formatter.SourceFormatter$1.call(SourceFormatter.java:177)
     [java] 	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
     [java] 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
     [java] 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
     [java] 	at java.lang.Thread.run(Thread.java:748)
     [java] Java Result: 1
 but ant format-source is successful. 

My journey to the solution:
**Case 1:**        
       I could see the permission check fail at WorkflowTaskPermissionChecker -> hasPermission
        if (!permissionChecker.isContentReviewer(
				permissionChecker.getCompanyId(), groupId)) {
			return false;
		}
	keep debuging to AdvancedPermissionChecker -> isContentReviewerImpl(long companyId, long groupId)
	and see it return false because user is not content reviewer for groupId. 		
	Go to database to check groupdId 20133 from lportal.Group_ and realize it's Control Panel -> not a site groupdId.
	GroupId in lportal.KaleoTaskInstanceToken table is different number -> it's site's groupId
	My solution is find the right groupdId of WorkflowTask -> get groupdId from WorkflowTask -> OptionalAttributes	
    **Case 2:**    
      The permission check fail at the same place because user is not Site Admin or Site Reviewer, have to check user has view permission for specific asset.      
      My first thinking about get entryClassName and entryClassPK from WorkflowTask -> OptionalAttributes and pass to 
      PermissionChecker -> hasPermission(long groupId, String name, String primKey, String actionId); with 'VIEW' action
      but it does not work out because groupId, name, primKey don't macth.
      Go around to find the way to check the VIEW permission of asset from entryClassName and entryClassPK, have found 
      AssetRenderer assetRenderer = workflowTaskDisplayContext.getAssetRenderer(); from view_content.js and AssetRenderer has method hasViewPermission(PermissionChecker permissionChecker). From WorkflowTaskDisplayContext.java found the way to get AssetRender from WorkflowTask -> Write a new method to check view permission is the solution.
	