### PR TITLE
[TS] [Prompt4-2] Not exposed the application server's port

### DIFF
--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -4993,35 +4993,7 @@ public class PortalImpl implements Portal {
 				company.getVirtualHostname(), getPortalServerPort(false),
 				false));
 
-		sb.append(getPathFriendlyURLPrivateGroup());
-
-		if ((group != null) && !group.isControlPanel()) {
-			sb.append(group.getFriendlyURL());
-			sb.append(VirtualLayoutConstants.CANONICAL_URL_SEPARATOR);
-		}
-
-		sb.append(GroupConstants.CONTROL_PANEL_FRIENDLY_URL);
-		sb.append(PropsValues.CONTROL_PANEL_LAYOUT_FRIENDLY_URL);
-
-		if (params != null) {
-			params = new LinkedHashMap<>(params);
-		}
-		else {
-			params = new LinkedHashMap<>();
-		}
-
-		if (Validator.isNotNull(ppid)) {
-			params.put("p_p_id", new String[] {ppid});
-		}
-
-		params.put("p_p_lifecycle", new String[] {"0"});
-		params.put(
-			"p_p_state", new String[] {WindowState.MAXIMIZED.toString()});
-		params.put("p_p_mode", new String[] {PortletMode.VIEW.toString()});
-
-		sb.append(HttpUtil.parameterMapToString(params, true));
-
-		return sb.toString();
+		return _getSiteAdminURL(sb, group, ppid, params);
 	}
 
 	/**
@@ -5038,6 +5010,19 @@ public class PortalImpl implements Portal {
 			group.getCompanyId());
 
 		return getSiteAdminURL(company, group, ppid, params);
+	}
+
+	@Override
+	public String getSiteAdminURL(
+			String portalURL, Group group, String ppid,
+			Map<String, String[]> params)
+		throws PortalException {
+
+		StringBundler sb = new StringBundler(7);
+
+		sb.append(portalURL);
+
+		return _getSiteAdminURL(sb, group, ppid, params);
 	}
 
 	/**
@@ -8635,6 +8620,41 @@ public class PortalImpl implements Portal {
 		catch (Exception e) {
 			return layout.getGroupId();
 		}
+	}
+
+	private String _getSiteAdminURL(
+		StringBundler sb, Group group, String ppid,
+		Map<String, String[]> params) {
+
+		sb.append(getPathFriendlyURLPrivateGroup());
+
+		if ((group != null) && !group.isControlPanel()) {
+			sb.append(group.getFriendlyURL());
+			sb.append(VirtualLayoutConstants.CANONICAL_URL_SEPARATOR);
+		}
+
+		sb.append(GroupConstants.CONTROL_PANEL_FRIENDLY_URL);
+		sb.append(PropsValues.CONTROL_PANEL_LAYOUT_FRIENDLY_URL);
+
+		if (params != null) {
+			params = new LinkedHashMap<>(params);
+		}
+		else {
+			params = new LinkedHashMap<>();
+		}
+
+		if (Validator.isNotNull(ppid)) {
+			params.put("p_p_id", new String[] {ppid});
+		}
+
+		params.put("p_p_lifecycle", new String[] {"0"});
+		params.put(
+			"p_p_state", new String[] {WindowState.MAXIMIZED.toString()});
+		params.put("p_p_mode", new String[] {PortletMode.VIEW.toString()});
+
+		sb.append(HttpUtil.parameterMapToString(params, true));
+
+		return sb.toString();
 	}
 
 	private Group _getSiteGroup(long groupId) throws PortalException {

--- a/portal-kernel/src/com/liferay/portal/kernel/util/Portal.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/Portal.java
@@ -1093,6 +1093,11 @@ public interface Portal {
 			Group group, String ppid, Map<String, String[]> params)
 		throws PortalException;
 
+	public String getSiteAdminURL(
+			String portalURL, Group group, String ppid,
+			Map<String, String[]> params)
+		throws PortalException;
+
 	/**
 	 * @deprecated As of 7.0.0, replaced by {@link
 	 *             #getCurrentAndAncestorSiteGroupIds(long)}

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PortalUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PortalUtil.java
@@ -1769,6 +1769,14 @@ public class PortalUtil {
 		return getPortal().getSiteAdminURL(group, ppid, params);
 	}
 
+	public static String getSiteAdminURL(
+			String portalURL, Group group, String ppid,
+			Map<String, String[]> params)
+		throws PortalException {
+
+		return getPortal().getSiteAdminURL(portalURL, group, ppid, params);
+	}
+
 	/**
 	 * @deprecated As of 7.0.0, replaced by {@link
 	 *             #getCurrentAndAncestorSiteGroupIds(long)}

--- a/portal-web/docroot/html/common/themes/top_js.jspf
+++ b/portal-web/docroot/html/common/themes/top_js.jspf
@@ -248,7 +248,7 @@
 				return '<%= PropsValues.SESSION_ENABLE_URL_WITH_SESSION_ID ? session.getId() : StringPool.BLANK %>';
 			},
 			getSiteAdminURL: function() {
-				return '<%= PortalUtil.getSiteAdminURL(themeDisplay.getCompany(), themeDisplay.getScopeGroup(), StringPool.BLANK, null) %>';
+				return '<%= PortalUtil.getSiteAdminURL(themeDisplay.getPortalURL(), themeDisplay.getScopeGroup(), StringPool.BLANK, null) %>';
 			},
 			getSiteGroupId: function() {
 				return '<%= themeDisplay.getSiteGroupId() %>';


### PR DESCRIPTION
Hi @holatuwol 

I have finish this prompt 4 part 2.

In this prompt, after reproduce the issue. I use Eclipse IDE for debug and search "getSiteAdminURL" with file name pattern is "\*.*".

I see that from top_js.jsp file, getSiteAdminURL function is returned:

`return '<%= PortalUtil.getSiteAdminURL(themeDisplay.getCompany(), themeDisplay.getScopeGroup(), StringPool.BLANK, null) %>';`

At PortalUtil class, it call method getSiteAdminURL of Portal interface
PortalImpl implement Portal interface and override this method.
The root cause is portal url get from:
```
             sb.append(
			getPortalURL(
				company.getVirtualHostname(), getPortalServerPort(false),
				false));
```
I check some other places (like getLayoutURL), the portal url get from ThemDisplay, it will show the IP address and not include port number. The company parameter is just use for getVirtualHostname.

So I think solution is when call method getSiteAdminURL of PortalUtil, change `themeDisplay.getCompany() to themeDisplay.getPortalURL()`
`return '<%= PortalUtil.getSiteAdminURL(themeDisplay.getPortalURL(), themeDisplay.getScopeGroup(), StringPool.BLANK, null) %>';`

And then we only need add this param to StringBundler.
`sb.append(portalURL);`

And I also create some new methods for this changed.
After test ok with http protocol, I also change httpd-vhosts.conf use ajp protocol and it also work right.
I use command git rev-parse HEAD to get SHA1 hashes of HEAD for run source code format
```
ant setup-sdk compile
cd portal-impl
ant format-source-current-branch -Dgit.working.branch.name=7a9cc3ca607baa5fdc69cff89b46dea8471899df
```
Please help me review it.
Thank you.