### PR TITLE
[TS][Prompt-5] Fix groupId and remove contentReviewerChecker logic

### DIFF
--- a/modules/apps/forms-and-workflow/portal-workflow/portal-workflow-task-web/src/main/java/com/liferay/portal/workflow/task/web/permission/WorkflowTaskPermissionChecker.java
+++ b/modules/apps/forms-and-workflow/portal-workflow/portal-workflow-task-web/src/main/java/com/liferay/portal/workflow/task/web/permission/WorkflowTaskPermissionChecker.java
@@ -26,38 +26,18 @@ import com.liferay.portal.kernel.workflow.WorkflowTaskAssignee;
  */
 public class WorkflowTaskPermissionChecker {
 
-	public boolean hasPermission(
+	public boolean hasAssignPermission(
 		long groupId, WorkflowTask workflowTask,
 		PermissionChecker permissionChecker) {
 
-		if (permissionChecker.isOmniadmin() ||
-			permissionChecker.isCompanyAdmin()) {
+		return _hasPermission(groupId, workflowTask, permissionChecker, true);
+	}
 
-			return true;
-		}
+	public boolean hasViewPermission(
+		long groupId, WorkflowTask workflowTask,
+		PermissionChecker permissionChecker) {
 
-		if (!permissionChecker.isContentReviewer(
-				permissionChecker.getCompanyId(), groupId)) {
-
-			return false;
-		}
-
-		long[] roleIds = permissionChecker.getRoleIds(
-			permissionChecker.getUserId(), groupId);
-
-		for (WorkflowTaskAssignee workflowTaskAssignee :
-				workflowTask.getWorkflowTaskAssignees()) {
-
-			if (isWorkflowTaskAssignableToRoles(
-					workflowTaskAssignee, roleIds) ||
-				isWorkflowTaskAssignableToUser(
-					workflowTaskAssignee, permissionChecker.getUserId())) {
-
-				return true;
-			}
-		}
-
-		return false;
+		return _hasPermission(groupId, workflowTask, permissionChecker, false);
 	}
 
 	protected boolean isWorkflowTaskAssignableToRoles(
@@ -89,6 +69,41 @@ public class WorkflowTaskPermissionChecker {
 
 		if (workflowTaskAssignee.getAssigneeClassPK() == userId) {
 			return true;
+		}
+
+		return false;
+	}
+
+	private boolean _hasPermission(
+		long groupId, WorkflowTask workflowTask,
+		PermissionChecker permissionChecker, boolean checkingAssignPermission) {
+
+		if (permissionChecker.isOmniadmin() ||
+			permissionChecker.isCompanyAdmin()) {
+
+			return true;
+		}
+
+		if (checkingAssignPermission &&
+			!permissionChecker.isContentReviewer(
+				permissionChecker.getCompanyId(), groupId)) {
+
+			return false;
+		}
+
+		long[] roleIds = permissionChecker.getRoleIds(
+			permissionChecker.getUserId(), groupId);
+
+		for (WorkflowTaskAssignee workflowTaskAssignee :
+				workflowTask.getWorkflowTaskAssignees()) {
+
+			if (isWorkflowTaskAssignableToRoles(
+					workflowTaskAssignee, roleIds) ||
+				isWorkflowTaskAssignableToUser(
+					workflowTaskAssignee, permissionChecker.getUserId())) {
+
+				return true;
+			}
 		}
 
 		return false;

--- a/modules/apps/forms-and-workflow/portal-workflow/portal-workflow-task-web/src/main/java/com/liferay/portal/workflow/task/web/portlet/MyWorkflowTaskPortlet.java
+++ b/modules/apps/forms-and-workflow/portal-workflow/portal-workflow-task-web/src/main/java/com/liferay/portal/workflow/task/web/portlet/MyWorkflowTaskPortlet.java
@@ -31,6 +31,7 @@ import com.liferay.portal.workflow.task.web.configuration.WorkflowTaskWebConfigu
 import com.liferay.portal.workflow.task.web.permission.WorkflowTaskPermissionChecker;
 
 import java.io.IOException;
+import java.io.Serializable;
 
 import java.util.Map;
 
@@ -123,9 +124,14 @@ public class MyWorkflowTaskPortlet extends MVCPortlet {
 			WorkflowTask workflowTask, ThemeDisplay themeDisplay)
 		throws PortalException {
 
-		if (!_workflowTaskPermissionChecker.hasPermission(
-				themeDisplay.getScopeGroupId(), workflowTask,
-				themeDisplay.getPermissionChecker())) {
+		final Map<String, Serializable> optionalAttributes =
+			workflowTask.getOptionalAttributes();
+
+		final long groupId = Long.parseLong(
+			(String)optionalAttributes.get("groupId"));
+
+		if (!_workflowTaskPermissionChecker.hasViewPermission(
+				groupId, workflowTask, themeDisplay.getPermissionChecker())) {
 
 			throw new PrincipalException(
 				String.format(

--- a/modules/apps/forms-and-workflow/portal-workflow/portal-workflow-task-web/src/main/java/com/liferay/portal/workflow/task/web/portlet/action/AssignTaskMVCActionCommand.java
+++ b/modules/apps/forms-and-workflow/portal-workflow/portal-workflow-task-web/src/main/java/com/liferay/portal/workflow/task/web/portlet/action/AssignTaskMVCActionCommand.java
@@ -24,6 +24,10 @@ import com.liferay.portal.kernel.workflow.WorkflowTask;
 import com.liferay.portal.kernel.workflow.WorkflowTaskManagerUtil;
 import com.liferay.portal.workflow.task.web.permission.WorkflowTaskPermissionChecker;
 
+import java.io.Serializable;
+
+import java.util.Map;
+
 import javax.portlet.ActionRequest;
 import javax.portlet.ActionResponse;
 
@@ -50,9 +54,14 @@ public class AssignTaskMVCActionCommand
 		WorkflowTask workflowTask = WorkflowTaskManagerUtil.getWorkflowTask(
 			themeDisplay.getCompanyId(), workflowTaskId);
 
-		if (!_workflowTaskPermissionChecker.hasPermission(
-				themeDisplay.getScopeGroupId(), workflowTask,
-				themeDisplay.getPermissionChecker())) {
+		final Map<String, Serializable> optionalAttributes =
+			workflowTask.getOptionalAttributes();
+
+		final long groupId = Long.parseLong(
+			(String)optionalAttributes.get("groupId"));
+
+		if (!_workflowTaskPermissionChecker.hasAssignPermission(
+				groupId, workflowTask, themeDisplay.getPermissionChecker())) {
 
 			throw new PrincipalException(
 				String.format(


### PR DESCRIPTION
Hi @holatuwol ,

I found that this bug related to MyWorklowTaskPortlet by the URL. Then I debug to see what happens here.
Firstly, I not quite understand what is `groupId`, then I go to database to check it and I found that it maybe the "site id". 
However `themeDisplay.getScopeGroupId()` return wrong `groupId` which is `control_panel` site not the site which has the portlet. So I fix it by get the real `groupId` from `workflowTask.optionalAttributes`.

From case 2: I saw that it will false at `permissionChecker.isContentReviewer()`. For me it not necessary, because the assignee of Workflow task could be by Role or User and following sentence already check it.
I also annotate at this condition to understand why the author write it at ticket [LPS-63813](https://issues.liferay.com/browse/LPS-63813). I test again with test case on this ticket and it still work well.
Because I cannot access to this ticket therefor I may not fully get the whole idea of this.

I'm not really confidence with this solution. Am I missing something? Please help me to review it.

BTW, I also run the format source code with:

```
ant setup-sdk compile
cd portal-impl
ant format-source-current-branch -Dgit.working.branch.name=0b366d695bacc6710d38e144d8fcfe94cd82fdb1
```

Thank you.


