### PR TITLE
LPS-116291: PortletResource only use in case PortletConfiguration for referencing the right portlet

### DIFF
--- a/portal-kernel/src/com/liferay/portal/kernel/util/PortletKeys.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PortletKeys.java
@@ -139,6 +139,10 @@ public class PortletKeys {
 	public static final String PORTAL_SETTINGS =
 		"com_liferay_portal_settings_web_portlet_PortalSettingsPortlet";
 
+	public static final String PORTLET_CONFIGURATION =
+		"com_liferay_portlet_configuration_web_portlet_" +
+			"PortletConfigurationPortlet";
+
 	public static final String PORTLET_DISPLAY_TEMPLATE =
 		"com_liferay_dynamic_data_mapping_web_portlet_" +
 			"PortletDisplayTemplatePortlet";

--- a/portal-web/docroot/html/portal/render_portlet.jsp
+++ b/portal-web/docroot/html/portal/render_portlet.jsp
@@ -160,16 +160,19 @@ String responseContentType = liferayRenderRequest.getResponseContentType();
 
 String currentURL = PortalUtil.getCurrentURL(request);
 
-String portletResource = ParamUtil.getString(request, "portletResource");
-
-if (Validator.isNull(portletResource)) {
-	portletResource = ParamUtil.getString(liferayRenderRequest, "portletResource");
-}
-
+String portletResource = StringPool.BLANK;
 Portlet portletResourcePortlet = null;
 
-if (Validator.isNotNull(portletResource)) {
-	portletResourcePortlet = PortletLocalServiceUtil.getPortletById(company.getCompanyId(), portletResource);
+if(PortletKeys.PORTLET_CONFIGURATION.equals(portletId)) {
+	portletResource = ParamUtil.getString(request, "portletResource");
+
+	if (Validator.isNull(portletResource)) {
+		portletResource = ParamUtil.getString(liferayRenderRequest, "portletResource");
+	}
+
+	if (Validator.isNotNull(portletResource)) {
+		portletResourcePortlet = PortletLocalServiceUtil.getPortletById(company.getCompanyId(), portletResource);
+	}
 }
 
 boolean showCloseIcon = true;


### PR DESCRIPTION
@holatuwol, @binhtran92, @vsingleton
 I created the PR to start the discussion for this ticket's solution.

From @binhtran92

> I found that the `portletResource` was introduced because the `PortletConfiguration` is loaded from different porlet. So they need that param to get preferences from the right portlet, as said from ticket https://issues.liferay.com/browse/LPS-44445.
> 
> However, I think when doing the refactor dependency at ticket https://issues.liferay.com/browse/LPS-55833, the author may assume that the PortletConfiguration is on all plugins (Portal and Market) then he decided to remove the condition.
> 
> So, my solution is, only set the portletResource if the portlet is PortletConfiguration. If not, just leave it as it is like the time this param was introduced.

I tested this solution and it worked fine.
But I saw 2 commits liferay@42c5f1f and liferay@2670193 . The `PORTLET_CONFIGURATION` was using in many places. This commit only partially reverted the code. I am not sure if it will affect other features or not.

What do you think about this, @holatuwol  ? 

Regards,
Hau Bui
