### PR TITLE
[TS] [Prompt2] Asset Tags

### DIFF
--- a/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetTagLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetTagLocalServiceImpl.java
@@ -122,7 +122,6 @@ public class AssetTagLocalServiceImpl extends AssetTagLocalServiceBaseImpl {
 		List<AssetTag> tags = new ArrayList<>();
 
 		for (String name : names) {
-
 			name = StringUtil.toLowerCase(StringUtil.trim(name));
 			AssetTag tag = fetchTag(group.getGroupId(), name);
 

--- a/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetTagLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetTagLocalServiceImpl.java
@@ -122,6 +122,8 @@ public class AssetTagLocalServiceImpl extends AssetTagLocalServiceBaseImpl {
 		List<AssetTag> tags = new ArrayList<>();
 
 		for (String name : names) {
+
+			name = StringUtil.toLowerCase(StringUtil.trim(name));
 			AssetTag tag = fetchTag(group.getGroupId(), name);
 
 			if (tag == null) {


### PR DESCRIPTION
When fetching tags by name, no matches are returned since it's passing an unformatted "name" variable as a parameter.
Another approach is to format the strings as they are added to the tags UI, but since that feature is not present in the current branch, I opted to make the changes on the backend side.