### PR TITLE
[TS Prompt 2-2] DM Folder Name WCM Collab Prompt

### DIFF
--- a/modules/apps/collaboration/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_entries.jsp
+++ b/modules/apps/collaboration/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_entries.jsp
@@ -503,7 +503,7 @@ if (portletTitleBasedNavigation && (folderId != DLFolderConstants.DEFAULT_PARENT
 									actionJspServletContext="<%= application %>"
 									resultRow="<%= row %>"
 									rowChecker="<%= entriesChecker %>"
-									text="<%= HtmlUtil.escape(curFolder.getName()) %>"
+									text="<%=curFolder.getName() %>"
 									url="<%= rowURL.toString() %>"
 								>
 									<liferay-frontend:horizontal-card-col>

--- a/modules/apps/collaboration/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_entries.jsp
+++ b/modules/apps/collaboration/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_entries.jsp
@@ -503,7 +503,7 @@ if (portletTitleBasedNavigation && (folderId != DLFolderConstants.DEFAULT_PARENT
 									actionJspServletContext="<%= application %>"
 									resultRow="<%= row %>"
 									rowChecker="<%= entriesChecker %>"
-									text="<%=curFolder.getName() %>"
+									text="<%= curFolder.getName() %>"
 									url="<%= rowURL.toString() %>"
 								>
 									<liferay-frontend:horizontal-card-col>


### PR DESCRIPTION
The problem was already discussed or pinpointed in the demo videos. What I had to do is to figure out how to display ampersand properly and looking into the code, it’s calling HtmlUtil.escape before displaying the folder name.
I checked the implementation of escape function and it’s replacing ‘&’ with ‘&amp’.

I googled about it and I learned that HTML uses ampersand symbol to escape other symbols that has other meaning like the less than symbol (<) which has ‘&lt’ as the code to display it.  So I guess in this case, we don’t need to escape it because we are not expecting other interpretation or meaning but just to display it. Also, I checked other curFolder.getName() in the same file and it’s not using/calling Html.escape function, so I just removed it, and it works fine (displayed ampersand correctly.