### PR TITLE
LPS-120550: Hide Relaunch, Summary menu item for backGroundTask upgraded from 6.2

### DIFF
--- a/modules/apps/staging/staging-taglib/src/main/resources/META-INF/resources/process_list_menu/init.jsp
+++ b/modules/apps/staging/staging-taglib/src/main/resources/META-INF/resources/process_list_menu/init.jsp
@@ -23,6 +23,15 @@ boolean localPublishing = GetterUtil.getBoolean(request.getAttribute("liferay-st
 boolean relaunchMenu = GetterUtil.getBoolean(request.getAttribute("liferay-staging:process-list-menu:relaunchMenu"));
 boolean summaryMenu = GetterUtil.getBoolean(request.getAttribute("liferay-staging:process-list-menu:summaryMenu"));
 
+Map<String, Serializable> contextMap = backgroundTask.getTaskContextMap();
+
+long exportImportConfigurationId = GetterUtil.getLong(String.valueOf(contextMap.get("exportImportConfigurationId")));
+
+if (exportImportConfigurationId == 0) {
+	relaunchMenu = false;
+	summaryMenu = false;
+}
+
 Date completionDate = backgroundTask.getCompletionDate();
 
 String deleteLabel = LanguageUtil.get(request, ((completionDate != null) && completionDate.before(new Date())) ? "clear" : "cancel");

--- a/modules/apps/staging/staging-taglib/src/main/resources/META-INF/resources/process_list_menu/items/summary.jspf
+++ b/modules/apps/staging/staging-taglib/src/main/resources/META-INF/resources/process_list_menu/items/summary.jspf
@@ -17,10 +17,6 @@
 <%
 String processCmd = null;
 
-Map<String, Serializable> contextMap = backgroundTask.getTaskContextMap();
-
-long exportImportConfigurationId = MapUtil.getLong(contextMap, "exportImportConfigurationId");
-
 if (exportImportConfigurationId > 0) {
 	ExportImportConfiguration exportImportConfiguration = ExportImportConfigurationLocalServiceUtil.getExportImportConfiguration(exportImportConfigurationId);
 


### PR DESCRIPTION
Hi @holatuwol, please help me review this PR.

Ticket is https://issues.liferay.com/browse/LPS-120550

Based on the discussion on slack, we will hide 2 options `Relaunch` and `Summary` when the `exportImportConfigurationId` parameter doesn't exists, because it will cause error in [init.jsp#L36-L44](https://github.com/liferay/liferay-portal-ee/blob/master/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/process_summary/init.jsp#L36-L44) and [EditPublishConfigurationMVCActionCommand.java#L187](https://github.com/liferay/liferay-portal/blob/ab15fb32bd58e4f218c8270be54ba8a835e253b7/modules/apps/staging/staging-processes-web/src/main/java/com/liferay/staging/processes/web/internal/portlet/action/EditPublishConfigurationMVCActionCommand.java#L187)

cc @tototrinh
Thanks so much.