### PR TITLE
LPS-134832 SearchPhaseExecutionException when using special char in keyword for AP filter

### DIFF
--- a/portal-impl/src/com/liferay/portlet/asset/util/AssetSearcher.java
+++ b/portal-impl/src/com/liferay/portlet/asset/util/AssetSearcher.java
@@ -164,7 +164,9 @@ public class AssetSearcher extends BaseSearcher {
 				keyword = StringUtil.quote(keyword, CharPool.QUOTE);
 			}
 
-			StringQuery stringQuery = new StringQuery(keyword);
+			String escapedKeyword = keyword.replace("/", "\\/");
+
+			StringQuery stringQuery = new StringQuery(escapedKeyword);
 
 			keywordsQuery.add(stringQuery, BooleanClauseOccur.MUST);
 		}


### PR DESCRIPTION
Hi @holatuwol ,
This is the fix for the ticket [LPP-41697](https://issues.liferay.com/browse/LPP-41697?filter=49020) and [LPS-134832](https://issues.liferay.com/browse/LPS-134832)

Please help me review it.
Thank you so much.