### PR TITLE
[Fix Review]-LPP-41919

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/preview.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/preview.js
@@ -146,9 +146,11 @@ AUI.add(
 							instance._getLoadingCountNode()
 						);
 
-						instance._imageListContent
-							.get('parentNode')
-							.append(loadingIndicator);
+						if(instance._imageListContent) {
+							instance._imageListContent
+								.get('parentNode')
+								.append(loadingIndicator);
+						}
 
 						instance._loadingIndicator = loadingIndicator;
 					}
@@ -531,24 +533,26 @@ AUI.add(
 
 					var imageListContent = instance._imageListContent;
 
-					imageListContent.delegate(
-						'mouseenter',
-						instance._onImageListMouseEnter,
-						'a',
-						instance
-					);
-					imageListContent.delegate(
-						STR_CLICK,
-						instance._onImageListClick,
-						'a',
-						instance
-					);
+					if(imageListContent) {
+						imageListContent.delegate(
+							'mouseenter',
+							instance._onImageListMouseEnter,
+							'a',
+							instance
+						);
+						imageListContent.delegate(
+							STR_CLICK,
+							instance._onImageListClick,
+							'a',
+							instance
+						);
 
-					imageListContent.on(
-						'scroll',
-						instance._onImageListScroll,
-						instance
-					);
+						imageListContent.on(
+							'scroll',
+							instance._onImageListScroll,
+							instance
+						);
+					}
 				},
 
 				initializer() {
@@ -577,7 +581,9 @@ AUI.add(
 					instance._renderToolbar();
 					instance._renderImages();
 
-					instance._actionContent.show();
+					if(instance._actionContent) {
+						instance._actionContent.show();
+					}
 				},
 			},
 		});


### PR DESCRIPTION
**Error:** Javascript error with null values in Asset Publisher.

**Explanation:** The template of this web content had imported has type "abstract", so when the abstract view is used, the nodes relating to it are also not already in the DOM, so the document hasn’t loaded yet, this approach fails—the first call to Y.one() in the YUI module will fail to find these nodes, and just return null. In this web content, the div tags haven't loaded yet, so the parameters that are passed in the script will be null and make this error. When you do something like view asset content or do preview it. The template will be called, this time the document(div) loaded and the parameters of the script have value so don't have error.

**Solution:** Catch and handle that error by check null.
Besides, there is another solution is to change the template type to "full_content": I don't appreciate this solution because it'll view all data and it's not suitable with list display, moreover it same with template when we click to view its content, so view it here is redundant.
![template](https://user-images.githubusercontent.com/76944107/127772939-7ac276f7-e7d7-4700-982a-583f5d36c9e9.png)
