### PR TITLE
[TS] LPS-138379 portal-web: Append namespace to remove the proper parameter

### DIFF
--- a/portal-web/docroot/html/taglib/ui/page_iterator/lexicon/start.jsp
+++ b/portal-web/docroot/html/taglib/ui/page_iterator/lexicon/start.jsp
@@ -349,7 +349,7 @@ NumberFormat numberFormat = NumberFormat.getNumberInstance(locale);
 					namespace: '<%= namespace %>',
 					pages: '<%= pages %>',
 					randomNamespace: '<%= randomNamespace %>',
-					url: '<%= HtmlUtil.escapeJS(HttpUtil.removeParameter(url, curParam)) %>',
+					url: '<%= HtmlUtil.escapeJS(HttpUtil.removeParameter(url, namespace + curParam)) %>',
 					urlAnchor: '<%= urlAnchor %>'
 				}
 			),


### PR DESCRIPTION
Hey @holatuwol ,

https://issues.liferay.com/browse/LPS-138379

This fix is related to a fix you worked on: [Scrolling does not work in intermediate pages of the page-iterator tag library](https://issues.liferay.com/browse/LPS-131653)

Just wanted to run this by you, in case there's anything I overlooked.

Can you help take a look?
Thanks!