### PR TITLE
LPS-139565 transform inline width and height css of img tag to img attribute due to CKEditor V4.14.1

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/ckeditor.jsp
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/ckeditor.jsp
@@ -152,8 +152,7 @@ name = HtmlUtil.escapeJS(name);
 			data =
 				'<%= (contents != null) ? HtmlUtil.escapeJS(contents) : StringPool.BLANK %>';
 		}
-
-		return data;
+		return Liferay.Util.transformInlineCSS(data);
 	};
 
 	var onLocaleChangedHandler = function (event) {
@@ -301,6 +300,8 @@ name = HtmlUtil.escapeJS(name);
 
 		setHTML: function (value) {
 			var ckEditorInstance = CKEDITOR.instances['<%= name %>'];
+
+			value = Liferay.Util.transformInlineCSS(value);
 
 			var win = window['<%= name %>'];
 

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/Editor.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/Editor.js
@@ -29,7 +29,12 @@ const Editor = React.forwardRef((props, ref) => {
 		});
 	}, []);
 
-	return <CKEditor ref={ref} {...props} />;
+	return (
+		<CKEditor
+			ref={ref}
+			{...Object.assign(props, {data: Liferay.Util.transformInlineCSS(props.data)})}
+		/>
+	);
 });
 
 CKEditor.editorUrl = `${BASEPATH}ckeditor.js`;

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/InlineEditor.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/InlineEditor.js
@@ -18,7 +18,12 @@ import React from 'react';
 const BASEPATH = '/o/frontend-editor-ckeditor-web/ckeditor/';
 
 const InlineEditor = (props) => {
-	return <CKEditor {...props} type="inline" />;
+	return (
+		<CKEditor
+			{...Object.assign(props, {data: Liferay.Util.transformInlineCSS(props.data)})}
+			type="inline"
+		/>
+	);
 };
 
 CKEditor.editorUrl = `${BASEPATH}ckeditor.js`;

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/global.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/global.es.js
@@ -75,6 +75,7 @@ import createResourceURL from './util/portlet_url/create_resource_url.es';
 import {getSessionValue, setSessionValue} from './util/session.es';
 import toCharCode from './util/to_char_code.es';
 import toggleDisabled from './util/toggle_disabled';
+import transformInlineCSS from './util/transform_inline_CSS';
 
 Liferay = window.Liferay || {};
 
@@ -271,5 +272,6 @@ Liferay.Util.Session = {
 
 Liferay.Util.unescape = unescape;
 Liferay.Util.unescapeHTML = unescapeHTML;
+Liferay.Util.transformInlineCSS = transformInlineCSS;
 
 export {portlet};

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/transform_inline_CSS.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/transform_inline_CSS.js
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+export default function transformInlineCSS(data) {
+	const parser = new DOMParser();
+	const htmlDoc = parser.parseFromString(data, 'text/html');
+	const imgTags = htmlDoc.getElementsByTagName('img');
+
+	for (let i = 0; i < imgTags.length; i++) {
+		const imgTag = imgTags[i];
+		if (
+			imgTag.getAttribute('width') !== null &&
+			imgTag.getAttribute('height') !== null
+		) {
+			continue;
+		}
+		const style = imgTag.getAttribute('style');
+
+		if (style === null || style === '') {
+			continue;
+		}
+
+		const styleHeight = imgTag.style.removeProperty('height');
+		if (styleHeight) {
+			imgTag.setAttribute('height', styleHeight.replace('px', ''));
+		}
+
+		const styleWidth = imgTag.style.removeProperty('width');
+		if (styleWidth) {
+			imgTag.setAttribute('width', styleWidth.replace('px', ''));
+		}
+	}
+
+	return htmlDoc.body.innerHTML;
+}


### PR DESCRIPTION
Hi @holatuwol ,
This is about the ticket https://issues.liferay.com/browse/LPP-42500
After upgrade to CKEditor V4.14.1, the width and height are no longer stored on the inline CSS of img tag.
So I create a DB upgrade task on Journal Service, that transforms the width and height to the img tag attribute.

I also sent you a PR here https://github.com/holatuwol/liferay-portal-ee/pull/114
This is for the 7.3.x. I also wonder why the branch `master` does not exist on  your liferay-portal-ee?
Thank you.