### PR TITLE
LPS-142767 Change skipEditorLoading to false

### DIFF
--- a/modules/apps/comment/comment-taglib/src/main/resources/META-INF/resources/discussion/js/Comments.js
+++ b/modules/apps/comment/comment-taglib/src/main/resources/META-INF/resources/discussion/js/Comments.js
@@ -162,7 +162,7 @@ export default function Comments({
 			const data = Liferay.Util.ns(namespace, {
 				className,
 				classPK,
-				skipEditorLoading: true,
+				skipEditorLoading: false,
 			});
 
 			Liferay.Portlet.refresh(`#p_p_id_${portletDisplayId}_`, data, true);


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-142767

When leaving a comment in Workflow task and then doing any of the tasks, assign to me, assign to, or  Update Due Date, the page will load with an error stating the CKEditor is not defined. I found that the URL contains `_skipEditorLoading=true` which is preventing CKEditor from loading.

I was able to change this variable to false and the page now loads the CKEditor correctly.
I tried testing other forms of this with wiki and message boards and I do not see a change. Let me know if this would be the best way to go about fixing this issue or if I should try something else.

Thank you!