### PR TITLE
LPS-151510 Images in HEIC format cannot be previewed in Documents and Media

### DIFF
--- a/modules/apps/adaptive-media/adaptive-media-image-api/src/main/java/com/liferay/adaptive/media/image/scaler/AMImageScaledImage.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-api/src/main/java/com/liferay/adaptive/media/image/scaler/AMImageScaledImage.java
@@ -38,6 +38,13 @@ public interface AMImageScaledImage {
 	public InputStream getInputStream();
 
 	/**
+	 * Returns the image mime type.
+	 *
+	 * @return the image mime type
+	 */
+	public String getMimeType();
+
+	/**
 	 * Returns this image's size in bytes.
 	 *
 	 * @return this image's size in bytes

--- a/modules/apps/adaptive-media/adaptive-media-image-impl/src/main/java/com/liferay/adaptive/media/image/internal/processor/AMImageProcessorImpl.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-impl/src/main/java/com/liferay/adaptive/media/image/internal/processor/AMImageProcessorImpl.java
@@ -28,6 +28,7 @@ import com.liferay.adaptive.media.processor.AMProcessor;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.repository.model.FileVersion;
+import com.liferay.portal.kernel.repository.model.FileVersionWrapper;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -121,8 +122,18 @@ public final class AMImageProcessorImpl implements AMImageProcessor {
 			try (InputStream inputStream =
 					amImageScaledImage.getInputStream()) {
 
+				FileVersionWrapper fileVersionWrapper = new FileVersionWrapper(
+					fileVersion) {
+
+					@Override
+					public String getMimeType() {
+						return amImageScaledImage.getMimeType();
+					}
+
+				};
+
 				_amImageEntryLocalService.addAMImageEntry(
-					amImageConfigurationEntry, fileVersion,
+					amImageConfigurationEntry, fileVersionWrapper,
 					amImageScaledImage.getHeight(),
 					amImageScaledImage.getWidth(), inputStream,
 					amImageScaledImage.getSize());

--- a/modules/apps/adaptive-media/adaptive-media-image-impl/src/main/java/com/liferay/adaptive/media/image/internal/scaler/AMDefaultImageScaler.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-impl/src/main/java/com/liferay/adaptive/media/image/internal/scaler/AMDefaultImageScaler.java
@@ -64,8 +64,8 @@ public class AMDefaultImageScaler implements AMImageScaler {
 			return new AMImageScaledImageImpl(
 				RenderedImageUtil.getRenderedImageContentStream(
 					scaledRenderedImage, fileVersion.getMimeType()),
-				scaledRenderedImage.getHeight(),
-				scaledRenderedImage.getWidth());
+				scaledRenderedImage.getHeight(), scaledRenderedImage.getWidth(),
+				fileVersion.getMimeType());
 		}
 		catch (AMRuntimeException.IOException | PortalException exception) {
 			throw new AMRuntimeException.IOException(

--- a/modules/apps/adaptive-media/adaptive-media-image-impl/src/main/java/com/liferay/adaptive/media/image/internal/scaler/AMGIFImageScaler.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-impl/src/main/java/com/liferay/adaptive/media/image/internal/scaler/AMGIFImageScaler.java
@@ -86,7 +86,8 @@ public class AMGIFImageScaler implements AMImageScaler {
 			Tuple<Integer, Integer> dimension = _getDimension(bytes);
 
 			return new AMImageScaledImageImpl(
-				bytes, dimension.second, dimension.first);
+				bytes, dimension.second, dimension.first,
+				fileVersion.getMimeType());
 		}
 		catch (ExecutionException | InterruptedException | IOException |
 			   PortalException | ProcessException exception) {

--- a/modules/apps/adaptive-media/adaptive-media-image-impl/src/main/java/com/liferay/adaptive/media/image/internal/scaler/AMImageMagickImageScaler.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-impl/src/main/java/com/liferay/adaptive/media/image/internal/scaler/AMImageMagickImageScaler.java
@@ -1,0 +1,161 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.adaptive.media.image.internal.scaler;
+
+import com.liferay.adaptive.media.exception.AMRuntimeException;
+import com.liferay.adaptive.media.image.configuration.AMImageConfigurationEntry;
+import com.liferay.adaptive.media.image.scaler.AMImageScaledImage;
+import com.liferay.adaptive.media.image.scaler.AMImageScaler;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.image.ImageBag;
+import com.liferay.portal.kernel.image.ImageMagick;
+import com.liferay.portal.kernel.image.ImageTool;
+import com.liferay.portal.kernel.repository.model.FileVersion;
+import com.liferay.portal.kernel.util.ContentTypes;
+import com.liferay.portal.kernel.util.FileUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
+
+import java.awt.image.RenderedImage;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Future;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Eric Yan
+ */
+@Component(
+	immediate = true, property = "mime.type=image/heic",
+	service = AMImageScaler.class
+)
+public class AMImageMagickImageScaler implements AMImageScaler {
+
+	@Override
+	public boolean isEnabled() {
+		if (_imageMagick.isEnabled()) {
+			return true;
+		}
+
+		return false;
+	}
+
+	@Override
+	public AMImageScaledImage scaleImage(
+		FileVersion fileVersion,
+		AMImageConfigurationEntry amImageConfigurationEntry) {
+
+		File imageFile = null;
+		File scaledImageFile = null;
+
+		try {
+			imageFile = _getFile(fileVersion);
+
+			scaledImageFile = _scaleAndConvertToPNG(
+				imageFile, amImageConfigurationEntry);
+
+			ImageBag imageBag = _imageTool.read(scaledImageFile);
+
+			RenderedImage renderedImage = imageBag.getRenderedImage();
+
+			return new AMImageScaledImageImpl(
+				_imageTool.getBytes(renderedImage, imageBag.getType()),
+				renderedImage.getHeight(), renderedImage.getWidth(),
+				ContentTypes.IMAGE_PNG);
+		}
+		catch (Exception exception) {
+			throw new AMRuntimeException.IOException(
+				StringBundler.concat(
+					"Unable to scale file entry ", fileVersion.getFileEntryId(),
+					" to match adaptive media configuration ",
+					amImageConfigurationEntry.getUUID()),
+				exception);
+		}
+		finally {
+			if (imageFile != null) {
+				imageFile.delete();
+			}
+
+			if (scaledImageFile != null) {
+				scaledImageFile.delete();
+			}
+		}
+	}
+
+	private File _getFile(FileVersion fileVersion)
+		throws IOException, PortalException {
+
+		try (InputStream inputStream = fileVersion.getContentStream(false)) {
+			return FileUtil.createTempFile(inputStream);
+		}
+	}
+
+	private String _getResizeArg(
+		AMImageConfigurationEntry amImageConfigurationEntry) {
+
+		Map<String, String> properties =
+			amImageConfigurationEntry.getProperties();
+
+		int maxHeight = GetterUtil.getInteger(properties.get("max-height"));
+		int maxWidth = GetterUtil.getInteger(properties.get("max-width"));
+
+		if ((maxHeight > 0) && (maxWidth > 0)) {
+			return StringBundler.concat(maxWidth, "x", maxHeight, ">");
+		}
+
+		return null;
+	}
+
+	private File _scaleAndConvertToPNG(
+			File imageFile, AMImageConfigurationEntry amImageConfigurationEntry)
+		throws Exception {
+
+		File scaledImageFile = FileUtil.createTempFile(ImageTool.TYPE_PNG);
+
+		List<String> arguments = new ArrayList<>();
+
+		arguments.add(imageFile.getAbsolutePath());
+
+		String resizeArg = _getResizeArg(amImageConfigurationEntry);
+
+		if (resizeArg != null) {
+			arguments.add("-resize");
+			arguments.add(resizeArg);
+		}
+
+		arguments.add(scaledImageFile.getAbsolutePath());
+
+		Future<?> future = _imageMagick.convert(arguments);
+
+		future.get();
+
+		return scaledImageFile;
+	}
+
+	@Reference
+	private ImageMagick _imageMagick;
+
+	@Reference
+	private ImageTool _imageTool;
+
+}

--- a/modules/apps/adaptive-media/adaptive-media-image-impl/src/main/java/com/liferay/adaptive/media/image/internal/scaler/AMImageScaledImageImpl.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-impl/src/main/java/com/liferay/adaptive/media/image/internal/scaler/AMImageScaledImageImpl.java
@@ -24,10 +24,13 @@ import java.io.InputStream;
  */
 public class AMImageScaledImageImpl implements AMImageScaledImage {
 
-	public AMImageScaledImageImpl(byte[] bytes, int height, int width) {
+	public AMImageScaledImageImpl(
+		byte[] bytes, int height, int width, String mimeType) {
+
 		_bytes = bytes;
 		_height = height;
 		_width = width;
+		_mimeType = mimeType;
 	}
 
 	@Override
@@ -38,6 +41,11 @@ public class AMImageScaledImageImpl implements AMImageScaledImage {
 	@Override
 	public InputStream getInputStream() {
 		return new UnsyncByteArrayInputStream(_bytes);
+	}
+
+	@Override
+	public String getMimeType() {
+		return _mimeType;
 	}
 
 	@Override
@@ -52,6 +60,7 @@ public class AMImageScaledImageImpl implements AMImageScaledImage {
 
 	private final byte[] _bytes;
 	private final int _height;
+	private final String _mimeType;
 	private final int _width;
 
 }

--- a/modules/apps/adaptive-media/adaptive-media-image-impl/src/test/java/com/liferay/adaptive/media/image/internal/processor/AMImageProcessorImplTest.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-impl/src/test/java/com/liferay/adaptive/media/image/internal/processor/AMImageProcessorImplTest.java
@@ -284,7 +284,7 @@ public class AMImageProcessorImplTest {
 				Mockito.any(FileVersion.class),
 				Mockito.any(AMImageConfigurationEntry.class))
 		).thenReturn(
-			new AMImageScaledImageImpl(new byte[100], 100, 100)
+			new AMImageScaledImageImpl(new byte[100], 100, 100, null)
 		);
 
 		_amImageProcessorImpl.process(
@@ -354,7 +354,7 @@ public class AMImageProcessorImplTest {
 				Mockito.any(FileVersion.class),
 				Mockito.any(AMImageConfigurationEntry.class))
 		).thenReturn(
-			new AMImageScaledImageImpl(new byte[100], 100, 100)
+			new AMImageScaledImageImpl(new byte[100], 100, 100, null)
 		);
 
 		_amImageProcessorImpl.process(
@@ -505,7 +505,7 @@ public class AMImageProcessorImplTest {
 		Mockito.when(
 			_amImageScaler.scaleImage(_fileVersion, amImageConfigurationEntry)
 		).thenReturn(
-			new AMImageScaledImageImpl(new byte[100], 150, 200)
+			new AMImageScaledImageImpl(new byte[100], 150, 200, null)
 		);
 
 		Mockito.doThrow(
@@ -557,7 +557,7 @@ public class AMImageProcessorImplTest {
 		Mockito.when(
 			_amImageScaler.scaleImage(_fileVersion, amImageConfigurationEntry)
 		).thenReturn(
-			new AMImageScaledImageImpl(new byte[100], 150, 200)
+			new AMImageScaledImageImpl(new byte[100], 150, 200, null)
 		);
 
 		_amImageProcessorImpl.process(_fileVersion);
@@ -676,7 +676,7 @@ public class AMImageProcessorImplTest {
 		Mockito.when(
 			_amImageScaler.scaleImage(_fileVersion, amImageConfigurationEntry)
 		).thenReturn(
-			new AMImageScaledImageImpl(new byte[100], 150, 200)
+			new AMImageScaledImageImpl(new byte[100], 150, 200, null)
 		);
 
 		Mockito.doThrow(


### PR DESCRIPTION
Hi @holatuwol ,

Ticket: https://issues.liferay.com/browse/LPS-151510

As discussed, this PR adds support for HEIC images to generate previews/thumbnails for Adaptive Media when ImageMagick (with HEIC support) is setup and enabled.

Can you help review this PR? 
Please see [LPP-44743](https://issues.liferay.com/browse/LPP-44743) for additional notes.

Thanks!