### PR TITLE
LPS-151510-2

### DIFF
--- a/modules/apps/adaptive-media/adaptive-media-document-library-thumbnails/src/main/java/com/liferay/adaptive/media/document/library/thumbnails/internal/processor/AMImageEntryProcessor.java
+++ b/modules/apps/adaptive-media/adaptive-media-document-library-thumbnails/src/main/java/com/liferay/adaptive/media/document/library/thumbnails/internal/processor/AMImageEntryProcessor.java
@@ -31,6 +31,7 @@ import com.liferay.document.library.security.io.InputStreamSanitizer;
 import com.liferay.exportimport.kernel.lar.PortletDataContext;
 import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.image.ImageTool;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.module.configuration.ConfigurationProvider;
@@ -50,6 +51,7 @@ import java.io.InputStream;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
@@ -168,6 +170,12 @@ public class AMImageEntryProcessor implements DLProcessor, ImageProcessor {
 
 	@Override
 	public String getPreviewType(FileVersion fileVersion) {
+		String previewType = _getType(fileVersion);
+
+		if (previewType != null) {
+			return previewType;
+		}
+
 		return _imageProcessor.getPreviewType(fileVersion);
 	}
 
@@ -216,6 +224,12 @@ public class AMImageEntryProcessor implements DLProcessor, ImageProcessor {
 
 	@Override
 	public String getThumbnailType(FileVersion fileVersion) {
+		String thumbnailType = _getType(fileVersion);
+
+		if (thumbnailType != null) {
+			return thumbnailType;
+		}
+
 		return _imageProcessor.getThumbnailType(fileVersion);
 	}
 
@@ -357,6 +371,16 @@ public class AMImageEntryProcessor implements DLProcessor, ImageProcessor {
 				PropsKeys.DL_FILE_ENTRY_THUMBNAIL_MAX_WIDTH),
 			PrefsPropsUtil.getInteger(
 				PropsKeys.DL_FILE_ENTRY_THUMBNAIL_MAX_HEIGHT));
+	}
+
+	private String _getType(FileVersion fileVersion) {
+		if ((fileVersion != null) &&
+			Objects.equals(fileVersion.getMimeType(), "image/heic")) {
+
+			return ImageTool.TYPE_PNG;
+		}
+
+		return null;
 	}
 
 	private boolean _isMimeTypeSupported(String mimeType) {

--- a/modules/apps/adaptive-media/adaptive-media-image-impl/src/main/java/com/liferay/adaptive/media/image/internal/processor/AMImageProcessorImpl.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-impl/src/main/java/com/liferay/adaptive/media/image/internal/processor/AMImageProcessorImpl.java
@@ -28,6 +28,9 @@ import com.liferay.adaptive.media.processor.AMProcessor;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.repository.model.FileVersion;
+import com.liferay.portal.kernel.repository.model.FileVersionWrapper;
+import com.liferay.portal.kernel.util.ContentTypes;
+import com.liferay.portal.kernel.util.MimeTypesUtil;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -121,8 +124,28 @@ public final class AMImageProcessorImpl implements AMImageProcessor {
 			try (InputStream inputStream =
 					amImageScaledImage.getInputStream()) {
 
+				String amImageScaledImageMimeType =
+					MimeTypesUtil.getContentType(
+						amImageScaledImage.getInputStream(), null);
+
+				FileVersionWrapper fileVersionWrapper = new FileVersionWrapper(
+					fileVersion) {
+
+					@Override
+					public String getMimeType() {
+						if (amImageScaledImageMimeType.equals(
+								ContentTypes.APPLICATION_OCTET_STREAM)) {
+
+							return fileVersion.getMimeType();
+						}
+
+						return amImageScaledImageMimeType;
+					}
+
+				};
+
 				_amImageEntryLocalService.addAMImageEntry(
-					amImageConfigurationEntry, fileVersion,
+					amImageConfigurationEntry, fileVersionWrapper,
 					amImageScaledImage.getHeight(),
 					amImageScaledImage.getWidth(), inputStream,
 					amImageScaledImage.getSize());

--- a/modules/apps/adaptive-media/adaptive-media-image-impl/src/main/java/com/liferay/adaptive/media/image/internal/scaler/AMDefaultImageScaler.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-impl/src/main/java/com/liferay/adaptive/media/image/internal/scaler/AMDefaultImageScaler.java
@@ -20,11 +20,13 @@ import com.liferay.adaptive.media.image.internal.processor.util.TiffOrientationT
 import com.liferay.adaptive.media.image.internal.util.RenderedImageUtil;
 import com.liferay.adaptive.media.image.scaler.AMImageScaledImage;
 import com.liferay.adaptive.media.image.scaler.AMImageScaler;
+import com.liferay.document.library.kernel.util.ImageProcessor;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.image.ImageTool;
 import com.liferay.portal.kernel.repository.model.FileVersion;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.MimeTypesUtil;
 
 import java.awt.image.RenderedImage;
 
@@ -61,9 +63,12 @@ public class AMDefaultImageScaler implements AMImageScaler {
 			RenderedImage scaledRenderedImage = _imageTool.scale(
 				renderedImage, maxHeight, maxWidth);
 
+			String targetImageMimeType = MimeTypesUtil.getExtensionContentType(
+				_imageProcessor.getPreviewType(fileVersion));
+
 			return new AMImageScaledImageImpl(
 				RenderedImageUtil.getRenderedImageContentStream(
-					scaledRenderedImage, fileVersion.getMimeType()),
+					scaledRenderedImage, targetImageMimeType),
 				scaledRenderedImage.getHeight(),
 				scaledRenderedImage.getWidth());
 		}
@@ -85,6 +90,9 @@ public class AMDefaultImageScaler implements AMImageScaler {
 			throw new AMRuntimeException.IOException(portalException);
 		}
 	}
+
+	@Reference
+	private ImageProcessor _imageProcessor;
 
 	@Reference
 	private ImageTool _imageTool;

--- a/modules/apps/adaptive-media/adaptive-media-image-impl/src/main/java/com/liferay/adaptive/media/image/internal/scaler/AMImageMagickImageScaler.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-impl/src/main/java/com/liferay/adaptive/media/image/internal/scaler/AMImageMagickImageScaler.java
@@ -1,0 +1,175 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.adaptive.media.image.internal.scaler;
+
+import com.liferay.adaptive.media.exception.AMRuntimeException;
+import com.liferay.adaptive.media.image.configuration.AMImageConfigurationEntry;
+import com.liferay.adaptive.media.image.internal.util.RenderedImageUtil;
+import com.liferay.adaptive.media.image.scaler.AMImageScaledImage;
+import com.liferay.adaptive.media.image.scaler.AMImageScaler;
+import com.liferay.document.library.kernel.util.ImageProcessor;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.image.ImageBag;
+import com.liferay.portal.kernel.image.ImageMagick;
+import com.liferay.portal.kernel.image.ImageTool;
+import com.liferay.portal.kernel.repository.model.FileVersion;
+import com.liferay.portal.kernel.util.FileUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.MimeTypesUtil;
+
+import java.awt.image.RenderedImage;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Future;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Eric Yan
+ */
+@Component(
+	immediate = true, property = "mime.type=image/heic",
+	service = AMImageScaler.class
+)
+public class AMImageMagickImageScaler implements AMImageScaler {
+
+	@Override
+	public boolean isEnabled() {
+		if (_imageMagick.isEnabled()) {
+			return true;
+		}
+
+		return false;
+	}
+
+	@Override
+	public AMImageScaledImage scaleImage(
+		FileVersion fileVersion,
+		AMImageConfigurationEntry amImageConfigurationEntry) {
+
+		File imageFile = null;
+		File scaledImageFile = null;
+
+		try {
+			imageFile = _getFile(fileVersion);
+
+			String targetImageType = _imageProcessor.getPreviewType(
+				fileVersion);
+
+			scaledImageFile = _scaleAndConvert(
+				imageFile, targetImageType, amImageConfigurationEntry);
+
+			ImageBag imageBag = _imageTool.read(scaledImageFile);
+
+			RenderedImage scaledRenderedImage = imageBag.getRenderedImage();
+
+			String targetImageMimeType = MimeTypesUtil.getExtensionContentType(
+				targetImageType);
+
+			return new AMImageScaledImageImpl(
+				RenderedImageUtil.getRenderedImageContentStream(
+					scaledRenderedImage, targetImageMimeType),
+				scaledRenderedImage.getHeight(),
+				scaledRenderedImage.getWidth());
+		}
+		catch (Exception exception) {
+			throw new AMRuntimeException.IOException(
+				StringBundler.concat(
+					"Unable to scale file entry ", fileVersion.getFileEntryId(),
+					" to match adaptive media configuration ",
+					amImageConfigurationEntry.getUUID()),
+				exception);
+		}
+		finally {
+			if (imageFile != null) {
+				imageFile.delete();
+			}
+
+			if (scaledImageFile != null) {
+				scaledImageFile.delete();
+			}
+		}
+	}
+
+	private File _getFile(FileVersion fileVersion)
+		throws IOException, PortalException {
+
+		try (InputStream inputStream = fileVersion.getContentStream(false)) {
+			return FileUtil.createTempFile(inputStream);
+		}
+	}
+
+	private String _getResizeArg(
+		AMImageConfigurationEntry amImageConfigurationEntry) {
+
+		Map<String, String> properties =
+			amImageConfigurationEntry.getProperties();
+
+		int maxHeight = GetterUtil.getInteger(properties.get("max-height"));
+		int maxWidth = GetterUtil.getInteger(properties.get("max-width"));
+
+		if ((maxHeight > 0) && (maxWidth > 0)) {
+			return StringBundler.concat(maxWidth, "x", maxHeight, ">");
+		}
+
+		return null;
+	}
+
+	private File _scaleAndConvert(
+			File imageFile, String targetImageFileExtension,
+			AMImageConfigurationEntry amImageConfigurationEntry)
+		throws Exception {
+
+		File scaledImageFile = FileUtil.createTempFile(
+			targetImageFileExtension);
+
+		List<String> arguments = new ArrayList<>();
+
+		arguments.add(imageFile.getAbsolutePath());
+
+		String resizeArg = _getResizeArg(amImageConfigurationEntry);
+
+		if (resizeArg != null) {
+			arguments.add("-resize");
+			arguments.add(resizeArg);
+		}
+
+		arguments.add(scaledImageFile.getAbsolutePath());
+
+		Future<?> future = _imageMagick.convert(arguments);
+
+		future.get();
+
+		return scaledImageFile;
+	}
+
+	@Reference
+	private ImageMagick _imageMagick;
+
+	@Reference
+	private ImageProcessor _imageProcessor;
+
+	@Reference
+	private ImageTool _imageTool;
+
+}


### PR DESCRIPTION
Hi @holatuwol ,

Previous PR: https://github.com/holatuwol/liferay-portal/pull/258

Here is another approach to add support for HEIC images. This approach takes more into consideration, the original implementation of the ImageProcessor, where the previewType dictates the image type of the generated image file.

However, currently it's more expensive, since it has to determine the mime type of the generated file before saving. If this can be further optimized, that would be great. (I couldn't figure out an easy way to do this without introducing a major version bump)